### PR TITLE
Correct a translation error and try to make + and - appear in the table

### DIFF
--- a/_posts/2025-06-29-hidden.md
+++ b/_posts/2025-06-29-hidden.md
@@ -77,7 +77,7 @@ in GraphViz DOT before generating a PNG file from it.
 
 ### The swap
 
-Firstly we can identify a `switch case` implemented as an `if`-cascade by the compiler.
+Firstly we can identify a `switch case` implemented as an nested `if` tree by the compiler.
 
 ![switch case cfg](/assets/img/lehack25/switch_case_cfg.png)
 
@@ -87,7 +87,7 @@ table":
 | Character A | Character B |
 | :---------: | :---------: |
 | _           | /           | 
-| +           | -           | 
+| \+          | \-          | 
 | ?           | !           | 
 | #           | @           | 
 
@@ -160,7 +160,7 @@ The same opeartion can be done with the `x/29bx $rsi` command if you break at th
     0x7fffffffeb60: 0x77    0x41    0x5f    0x21    0x0d    0x37    0x1c    0x0c
     0x7fffffffeb68: 0x27    0x26    0x2f    0x4b    0x12
 
-> The last part with `xmm0`and the complicated instructions was reversed for me
+> The last part with `xmm0` and the complicated instructions was reversed for me
 > by Ghidra. I only understood this part completely once at home.
 
 After having extracted these values, you can the reverse the cypher.


### PR DESCRIPTION
The markdown of the "swap table" in the "LeHACK 2025 - Hidden article" looks misinterpreted (works when I compile it with mdpdf). I added 2 escape chars to resolve that. Hope it will work.

The  other modifications are minor and don't really need a review (i.e there is normally no risks of differences between the code and its interpretation).